### PR TITLE
Fix return statement

### DIFF
--- a/src/connector_write_firestore.workflows.yaml
+++ b/src/connector_write_firestore.workflows.yaml
@@ -31,5 +31,5 @@
         - unhandledException:
             raise: ${e}
 - last:
-    return: ${writeResult.body}
+    return: ${writeResult.name}
 # [END workflows_connector_write_firestore]


### PR DESCRIPTION
writeResult doesn't have key 'body'. The result returned by patch API is a Document object: https://cloud.google.com/workflows/docs/reference/stdlib/googleapis/firestore/v1/Overview?hl=en#document

Either 'name' or 'fields' could be used as the key.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR