### PR TITLE
Fix return statement

### DIFF
--- a/src/connector_write_firestore.workflows.json
+++ b/src/connector_write_firestore.workflows.json
@@ -67,7 +67,7 @@
   },
   {
     "last": {
-      "return": "${writeResult.body}"
+      "return": "${writeResult.name}"
     }
   }
 ]


### PR DESCRIPTION
Key 'body' doesn't exist in writeResult. Use 'name' or 'fields' instead.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR