### PR TITLE
ci: add generated JSON check

### DIFF
--- a/.github/workflows/generated_json_check.yaml
+++ b/.github/workflows/generated_json_check.yaml
@@ -10,7 +10,9 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '12'
-    - name: Run Validate JSON Schema Script
+    - name: install yamljs CLI
+      run: npm install -g yamljs
+    - name: Run toJSON script
       run: ./tojson.sh
     - name: Ensure there is no diff
       run: git diff --exit-code .

--- a/.github/workflows/generated_json_check.yaml
+++ b/.github/workflows/generated_json_check.yaml
@@ -1,0 +1,16 @@
+name: Validate JSON
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+    - name: Run Validate JSON Schema Script
+      run: ./tojson.sh
+    - name: Ensure there is no diff
+      run: git diff --exit-code .


### PR DESCRIPTION
Adds a GitHub check to notify commits if the generator has been ran or not.

Note: The check should fail on purpose right now because the current `main` branch does not have the latest generated JSON.