### PR TITLE
ci: validate filenames

### DIFF
--- a/.github/workflows/filename_check.yaml
+++ b/.github/workflows/filename_check.yaml
@@ -1,0 +1,16 @@
+name: Validate Filename
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+    - name: Run toJSON script
+      run: ./tojson.sh
+    - name: Ensure there is no diff
+      run: git diff --exit-code .

--- a/.github/workflows/filename_check.yaml
+++ b/.github/workflows/filename_check.yaml
@@ -11,6 +11,4 @@ jobs:
       with:
         node-version: '12'
     - name: Run toJSON script
-      run: ./tojson.sh
-    - name: Ensure there is no diff
-      run: git diff --exit-code .
+      run: ./validateFilenames.sh

--- a/.github/workflows/filename_check.yaml
+++ b/.github/workflows/filename_check.yaml
@@ -10,5 +10,5 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '12'
-    - name: Run toJSON script
+    - name: Validate Filenames
       run: ./validateFilenames.sh

--- a/validateFilenames.sh
+++ b/validateFilenames.sh
@@ -1,0 +1,11 @@
+#/bin/bash
+
+workflowsFilePattern="*.workflows.yaml";
+
+cd src
+for path in $(find . -name '*.yaml'); do
+  [[ $path == $workflowsFilePattern ]] &&
+    echo "File is fine!" ||
+    echo "$path doesn't match *.workflows.yaml" &&
+    exit
+done

--- a/validateFilenames.sh
+++ b/validateFilenames.sh
@@ -15,4 +15,4 @@ for path in $(find . -name '*.yaml'); do
 done
 
 # Fail CI if a path doesn't match.
-if [[ $FAILED ]]; then exit 1;
+if [[ $FAILED ]]; then exit 1; fi

--- a/validateFilenames.sh
+++ b/validateFilenames.sh
@@ -3,10 +3,16 @@
 echo "Validating filenames..."
 workflowsFilePattern="*.workflows.yaml";
 
+# Check all workflow files to see if the file pattern is good.
 cd src
 for path in $(find . -name '*.yaml'); do
-  [[ $path == $workflowsFilePattern ]] &&
-    echo "File is fine!" ||
-    echo "$path doesn't match *.workflows.yaml" &&
-    exit
+  if [[ $path == $workflowsFilePattern ]]; then
+    echo "$path is fine!"
+  else
+    echo "$path doesn't match *.workflows.yaml"
+    FAILED=true
+  fi
 done
+
+# Fail CI if a path doesn't match.
+if [[ $FAILED ]]; then exit 1;

--- a/validateFilenames.sh
+++ b/validateFilenames.sh
@@ -1,5 +1,6 @@
 #/bin/bash
 
+echo "Validating filenames..."
 workflowsFilePattern="*.workflows.yaml";
 
 cd src


### PR DESCRIPTION
In order to have autocompletion for a workflow, a user must have the filename of `*.workflows.yaml`.

We should be consistent in this file name formatting.

This PR adds a check in all source files to ensure that the YAML files have the path of `*.workflows.yaml`

It's expected to fail right now because some filenames are not correct.