### PR TITLE
feat: add datetime function

### DIFF
--- a/functions/datetime/README.md
+++ b/functions/datetime/README.md
@@ -1,6 +1,6 @@
 # datetime
 
-A simple Cloud Function that returns the day of the week.
+A simple Cloud Function used in Workflow samples that returns the day of the week.
 
 ## Deploy
 

--- a/functions/datetime/README.md
+++ b/functions/datetime/README.md
@@ -1,0 +1,19 @@
+# datetime
+
+A simple Cloud Function that returns the day of the week.
+
+## Deploy
+
+```sh
+gcloud functions deploy datetime \
+--trigger-http \
+--entry-point getValue \
+--runtime python37 \
+--allow-unauthenticated
+```
+
+## Test
+
+```
+curl https://us-central1-workflowsample.cloudfunctions.net/datetime
+```

--- a/functions/datetime/main.py
+++ b/functions/datetime/main.py
@@ -1,0 +1,10 @@
+from flask import jsonify
+from datetime import date
+import calendar
+
+
+def getValue(request):
+    my_date = date.today()
+    day = calendar.day_name[my_date.weekday()]    
+    return jsonify({"dayOfTheWeek":day}), 200
+

--- a/functions/datetime/requirements.txt
+++ b/functions/datetime/requirements.txt
@@ -1,0 +1,3 @@
+# Function dependencies, for example:
+# package>=version
+flask>=1.0.2


### PR DESCRIPTION
Adds simple Cloud Function source code for `datetime` that is used in some samples.

- Adds Function source code
- Adds docs for deploy command and manual test command

Example deployment: https://us-central1-serverless-com-demo.cloudfunctions.net/datetime