### PR TITLE
fix: typo in document_found

### DIFF
--- a/src/connect_firestore_read.workflows.json
+++ b/src/connect_firestore_read.workflows.json
@@ -60,7 +60,7 @@
   },
   {
     "document_found": {
-      "return": "${documentValue.body.fields.LastName.stringValue}"
+      "return": "${document_value.body.fields.LastName.stringValue}"
     }
   }
 ]


### PR DESCRIPTION
document_found step referenced camelCased documentVale but read_item result uses document_value.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR