### PR TITLE
chore: update codeowners to aap-dpes team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @GoogleCloudPlatform/cdpe-serverless
+*     @GoogleCloudPlatform/aap-dpes


### PR DESCRIPTION
We're not using cdpe-serverless, incrementally working to deprecate.