### PR TITLE
testing: update node to v16

### DIFF
--- a/.github/workflows/generate_json_pr.yaml
+++ b/.github/workflows/generate_json_pr.yaml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
-        node-version: '12'
+        node-version: '16'
     - name: install yamljs CLI
       run: npm install -g yamljs
     - name: Run toJSON script

--- a/.github/workflows/generated_json_check.yaml
+++ b/.github/workflows/generated_json_check.yaml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
-        node-version: '12'
+        node-version: '16'
     - name: install yamljs CLI
       run: npm install -g yamljs
     - name: Run toJSON script


### PR DESCRIPTION
GitHub Actions are using Node v12, upgrade to v16.