### PR TITLE
fix: Adding Null check on Input param

### DIFF
--- a/src/quickstart.workflows.yaml
+++ b/src/quickstart.workflows.yaml
@@ -16,6 +16,11 @@
 main:
     params: [input]
     steps:
+    - checkInputExists:
+        switch:
+            - condition: ${input != null}
+              next: checkSearchTermInInput
+        next: getCurrentTime  
     - checkSearchTermInInput:
         switch:
             - condition: ${"searchTerm" in input}


### PR DESCRIPTION
The instructions provided on https://cloud.google.com/workflows/docs/create-workflow-gcloud#yaml fail with the run command provided as it did not include any --data elements. Adding in a null check to allow that scenario to succeed

Fixes #94 

- [x] Tests pass (ran the examples locally)
- [x] CL submitted for example docs
