### PR TITLE
fix: add main and step fields

### DIFF
--- a/src/connector_read_firestore.workflows.yaml
+++ b/src/connector_read_firestore.workflows.yaml
@@ -13,16 +13,18 @@
 # limitations under the License.
 
 # [START workflows_connector_read_firestore]
-- init_variables:
-    assign:
-      - project: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
-      - collection: "peopleDatabase"
-      - document: "smith.j"
-- read_from_firestore:
-    call: googleapis.firestore.v1.projects.databases.documents.get
-    args:
-      name: ${"projects/"+project+"/databases/(default)/documents/"+collection+"/"+document}
-    result: read_result
-- last:
-    return: ${read_result.fields}
+main:
+    steps:
+    - init_variables:
+        assign:
+          - project: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
+          - collection: "peopleDatabase"
+          - document: "smith.j"
+    - read_from_firestore:
+        call: googleapis.firestore.v1.projects.databases.documents.get
+        args:
+          name: ${"projects/"+project+"/databases/(default)/documents/"+collection+"/"+document}
+        result: read_result
+    - last:
+        return: ${read_result.fields}
 # [END workflows_connector_read_firestore]


### PR DESCRIPTION
Some sample include `main` and `steps` and some do not. These fields are need to be an actual workflow. Should we update this for all samples?