### PR TITLE
Add an empty sample workflow for Application Integration connector.

### DIFF
--- a/src/connectors/connector_integrations.workflows.yaml
+++ b/src/connectors/connector_integrations.workflows.yaml
@@ -1,0 +1,17 @@
+# Copyright 2020 Google LLC
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #      http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+
+# [START workflows_connector_integrations]
+# TO BE ADDED
+# [END workflows_connector_integrations]


### PR DESCRIPTION
Add an empty sample workflow. This should be filled with a real working workflow when connector goes GA.