### PR TITLE
fix: update syntax in step_conditional_weekend.workflows

### DIFF
--- a/src/step_conditional_weekend.workflows.yaml
+++ b/src/step_conditional_weekend.workflows.yaml
@@ -22,7 +22,7 @@
     switch:
       - condition: ${currentTime.body.dayOfTheWeek == "Friday"}
         next: friday
-      - condition: ${currentTime.body.dayOfTheWeek == "Saturday" OR currentTime.body.dayOfTheWeek == "Sunday"}
+      - condition: ${currentTime.body.dayOfTheWeek == "Saturday" or currentTime.body.dayOfTheWeek == "Sunday"}
         next: weekend
     next: workWeek
 - friday:


### PR DESCRIPTION
Update sample workflow:
changing `OR` to `or` (as per https://cloud.google.com/workflows/docs/reference/syntax/datatypes#logical-operators).

The (second) example in docs in [this section](https://cloud.google.com/workflows/docs/reference/syntax/conditions#conditional-steps) uses `OR` while logical operators are case-sensitive and `or` is the valid value (as per docs [here](https://cloud.google.com/workflows/docs/reference/syntax/datatypes#logical-operators))