### PR TITLE
feat: add Transcoder connector sample

### DIFF
--- a/src/connectors/connector_integrations.workflows.yaml
+++ b/src/connectors/connector_integrations.workflows.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 # #
 # # Licensed under the Apache License, Version 2.0 (the "License");
 # # you may not use this file except in compliance with the License.

--- a/src/connectors/connector_integrations.workflows.yaml
+++ b/src/connectors/connector_integrations.workflows.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2022 Google LLC
 # #
 # # Licensed under the Apache License, Version 2.0 (the "License");
 # # you may not use this file except in compliance with the License.

--- a/src/connectors/connector_transcoder.workflows.json
+++ b/src/connectors/connector_transcoder.workflows.json
@@ -1,0 +1,32 @@
+{
+  "main": {
+    "steps": [
+      {
+        "init": {
+          "assign": [
+            {
+              "project": "${sys.get_env(\"GOOGLE_CLOUD_PROJECT_ID\")}"
+            },
+            {
+              "location": "${sys.get_env(\"GOOGLE_CLOUD_LOCATION\")}"
+            }
+          ]
+        }
+      },
+      {
+        "get_list": {
+          "call": "googleapis.transcoder.v1.projects.locations.jobs.list",
+          "args": {
+            "parent": "${\"projects/\" + project + \"/locations/\" + location}"
+          },
+          "result": "response"
+        }
+      },
+      {
+        "the_end": {
+          "return": "${response}"
+        }
+      }
+    ]
+  }
+}

--- a/src/connectors/connector_transcoder.workflows.yaml
+++ b/src/connectors/connector_transcoder.workflows.yaml
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #      http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+
+# [START workflows_connector_transcoder]
+# This workflow demonstrates how to use the Transcoder API connector.
+# This workflow sends a List request to Transcoder API.
+main:
+  steps:
+    - init:
+        assign:
+          - project: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
+          - location: ${sys.get_env("GOOGLE_CLOUD_LOCATION")}
+    - get_list:
+        call: googleapis.transcoder.v1.projects.locations.jobs.list
+        args:
+          parent: ${"projects/" + project + "/locations/" + location}
+        result: response
+    - the_end:
+        return: ${response}
+# [END workflows_connector_transcoder]

--- a/src/connectors/connector_transcoder.workflows.yaml
+++ b/src/connectors/connector_transcoder.workflows.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 # #
 # # Licensed under the Apache License, Version 2.0 (the "License");
 # # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Docs: add a sample workflow for Transcoder connector

This is used for the Transcoder connector documentation.

CloudWorkflows team will be responsible for updating/maintaining this sample.