### PR TITLE
chore: remove pinned node version for github action

### DIFF
--- a/.github/workflows/generate_json_pr.yaml
+++ b/.github/workflows/generate_json_pr.yaml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
-        with:
-          node-version: "16"
 
       - name: Install yamljs CLI
         run: npm install -g yamljs


### PR DESCRIPTION
Other github actions also do this, should then track actions/setup-node default (which should be updated as needed)